### PR TITLE
Account widget icon update

### DIFF
--- a/source/icons/z1-account-widget.svg
+++ b/source/icons/z1-account-widget.svg
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="30.2" height="30.2" viewBox="0 0 30.2 30.2">
-  <defs>
-    <style>.cls-1 { fill: #eaeaea; }</style>
-  </defs>
-  <g id="strib-account-back">
     <circle fill="var(--strib-strib-account-back, #eaeaea)" class="cls-1" cx="15.1" cy="15.1" r="15.1"/>
-  </g>
-  <g id="strib-account-top">
-    <g>
+  <g fill="var(--strib-strib-account-top, #000000)">
       <path d="M8.53,13.05c0-3.3,2.7-6.1,6.1-6.1h0c3.4,0,6.1,2.7,6.1,6.1s-2.7,6.1-6.1,6.1-6.1-2.7-6.1-6.1Z"/>
       <path d="M25.24,26.305c-2.7,2.5-6.3,3.9-10.2,3.9-4.2,0-8.1-1.7-10.8-4.6,.7-3.4,2.3-6.4,4.8-8,2.5,3.1,7,3.6,10.1,1.2l1.2-1.2c2.6,1.7,4.3,5,4.9,8.7-.1,0,0,0,0,0Z"/>
-    </g>
   </g>
 </svg>


### PR DESCRIPTION
## Description
- Update the account widget icon so that the color variables can be properly utilized. This includes:
    - Removing the style definition from the SVG because that was overriding any colors set with `--strib-strib-account-top`
        - When previewing in an IDE like PHPStorm, this change means that the icon unfortunately looks like a big black circle. There may be a way around that, but I don't know what it would be at this time.
    - Applies `--strib-strib-account-bottom` to the parts of the person (head, body) so that those can also be customized
    - Removes the (seemingly?) unnecessary extra `<g>` level around the person parts